### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ The full set of components that have releases are:
 
 - `chain-mon`
 - `ci-builder`
-- `ci-builder`
 - `op-batcher`
 - `op-contracts`
 - `op-challenger`


### PR DESCRIPTION
There is a typo in the documentation. The same definition is repeated twice