### PR TITLE
Refined text by fixing typos and improving clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ The full set of components that have releases are:
 
 - `chain-mon`
 - `ci-builder`
-- `ci-builder`
 - `op-batcher`
 - `op-contracts`
 - `op-challenger`

--- a/packages/contracts-bedrock/CHANGELOG.md
+++ b/packages/contracts-bedrock/CHANGELOG.md
@@ -246,7 +246,7 @@
 
 ### Patch Changes
 
-- 88dde7c8: Uses assert rather than a require statements to check for conditions we believe are unreachable.This is more semantically explicit, and should enable us to more effectively use some advanced analysis methods in our testing.
+- 88dde7c8: Uses assert rather than require statements to check for conditions we believe are unreachable.This is more semantically explicit, and should enable us to more effectively use some advanced analysis methods in our testing.
 - 7215f4ce: Bump ethers to 5.7.0 globally
 - 249a8ed6: Fixed a backwards compatibility issue in which incorrect events were emitted during a failed deposit finalization on the L2 bridge.
 - 7d7c4fdf: Makes spacers private and updates names to reflect slot, offset, and length.
@@ -319,7 +319,7 @@
 - 45541553: Emit an extra event when withdrawals are initiated to make chainops easier
 - 3dd296e8: Fix portal deployment to have L2OutputOracle proxy address
 - fe94b864: Add watch task
-- 28649d64: Add harhdat forge contract verification support
+- 28649d64: Add hardhat forge contract verification support
 - 898c7ac5: Update hardhat-forge dep, remove dead deps
 - 51a1595b: bedrock-goerli-96f44f79 deployment
 - 8ae39154: Update deposit transaction type

--- a/packages/contracts-bedrock/STYLE_GUIDE.md
+++ b/packages/contracts-bedrock/STYLE_GUIDE.md
@@ -78,7 +78,7 @@ Immutable variables:
 
 - should be in `SCREAMING_SNAKE_CASE`
 - should be `internal`
-- should have a hand written getter function
+- should have a handwritten getter function
 
 This approach clearly indicates to the developer that the value is immutable, without exposing
 the non-standard casing to the interface. It also ensures that we don’t need to break the ABIs if


### PR DESCRIPTION
This pull request includes changes aimed at enhancing clarity, accuracy, and structure.

Description correction:

Removed the repetition of ci-builder.
"than a require statements" corrected to "than require statements."
harhdat corrected to hardhat.
"hand written" corrected to "handwritten."

Thank you for your work, and I hope this pull request is helpful!
