### PR TITLE
fix: remove conductor rollup config requirement

### DIFF
--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -10,8 +10,6 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/ethereum-optimism/optimism/op-conductor/flags"
-	opnode "github.com/ethereum-optimism/optimism/op-node"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
@@ -89,9 +87,6 @@ type Config struct {
 	// HealthCheck is the health check configuration.
 	HealthCheck HealthCheckConfig
 
-	// RollupCfg is the rollup config.
-	RollupCfg rollup.Config
-
 	// RPCEnableProxy is true if the sequencer RPC proxy should be enabled.
 	RPCEnableProxy bool
 
@@ -137,9 +132,6 @@ func (c *Config) Check() error {
 	if err := c.HealthCheck.Check(); err != nil {
 		return errors.Wrap(err, "invalid health check config")
 	}
-	if err := c.RollupCfg.Check(); err != nil {
-		return errors.Wrap(err, "invalid rollup config")
-	}
 	if err := c.MetricsConfig.Check(); err != nil {
 		return errors.Wrap(err, "invalid metrics config")
 	}
@@ -156,11 +148,6 @@ func (c *Config) Check() error {
 func NewConfig(ctx *cli.Context, log log.Logger) (*Config, error) {
 	if err := flags.CheckRequired(ctx); err != nil {
 		return nil, errors.Wrap(err, "missing required flags")
-	}
-
-	rollupCfg, err := opnode.NewRollupConfigFromCLI(log, ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to load rollup config")
 	}
 
 	executionP2pRpcUrl := ctx.String(flags.HealthcheckExecutionP2pRPCUrl.Name)
@@ -206,7 +193,6 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*Config, error) {
 			RollupBoostPartialHealthinessToleranceLimit:           ctx.Uint64(flags.HealthCheckRollupBoostPartialHealthinessToleranceLimit.Name),
 			RollupBoostPartialHealthinessToleranceIntervalSeconds: ctx.Uint64(flags.HealthCheckRollupBoostPartialHealthinessToleranceIntervalSeconds.Name),
 		},
-		RollupCfg:           *rollupCfg,
 		RPCEnableProxy:      ctx.Bool(flags.RPCEnableProxy.Name),
 		RollupBoostWsURL:    ctx.String(flags.RollupBoostWsURL.Name),
 		WebsocketServerPort: ctx.Int(flags.WebsocketServerPort.Name),

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -41,6 +41,9 @@ var (
 	ErrNoUnsafeHead       = errors.New("no unsafe head")
 )
 
+// clientCacheSize is the number of blocks that the client keeps a cache for
+const clientCacheSize = 1000
+
 // New creates a new OpConductor instance.
 func New(ctx context.Context, cfg *Config, log log.Logger, version string) (*OpConductor, error) {
 	return NewOpConductor(ctx, cfg, log, metrics.NewMetrics(), version, nil, nil, nil)
@@ -132,9 +135,10 @@ func (c *OpConductor) initSequencerControl(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create geth rpc client")
 	}
-	execCfg := sources.L2ClientDefaultConfig(&c.cfg.RollupCfg, true)
 	// TODO: Add metrics tracer here. tracked by https://github.com/ethereum-optimism/protocol-quest/issues/45
-	exec, err := sources.NewEthClient(ec, c.log, nil, &execCfg.EthClientConfig)
+
+	// use 1000 blocks as the span since this is the max value, and generally what is used
+	exec, err := sources.NewEthClient(ec, c.log, nil, sources.EthClientConfigWithSpan(true, clientCacheSize))
 	if err != nil {
 		return errors.Wrap(err, "failed to create geth client")
 	}
@@ -181,7 +185,6 @@ func (c *OpConductor) initConsensus(ctx context.Context) error {
 		ListenPort:         c.cfg.ConsensusPort,
 		StorageDir:         c.cfg.RaftStorageDir,
 		Bootstrap:          c.cfg.RaftBootstrap,
-		RollupCfg:          &c.cfg.RollupCfg,
 		SnapshotInterval:   c.cfg.RaftSnapshotInterval,
 		SnapshotThreshold:  c.cfg.RaftSnapshotThreshold,
 		TrailingLogs:       c.cfg.RaftTrailingLogs,
@@ -261,7 +264,6 @@ func (c *OpConductor) initHealthMonitor(ctx context.Context) error {
 		c.cfg.HealthCheck.SafeInterval,
 		c.cfg.HealthCheck.MinPeerCount,
 		c.cfg.HealthCheck.SafeEnabled,
-		&c.cfg.RollupCfg,
 		node,
 		p2p,
 		supervisor,

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -25,14 +24,12 @@ import (
 	"github.com/ethereum-optimism/optimism/op-conductor/health"
 	healthmocks "github.com/ethereum-optimism/optimism/op-conductor/health/mocks"
 	"github.com/ethereum-optimism/optimism/op-conductor/metrics"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
 
 func mockConfig(t *testing.T) Config {
-	now := uint64(time.Now().Unix())
 	return Config{
 		ConsensusAddr:  "127.0.0.1",
 		ConsensusPort:  0,
@@ -47,37 +44,6 @@ func mockConfig(t *testing.T) Config {
 			UnsafeInterval: 3,
 			SafeInterval:   5,
 			MinPeerCount:   1,
-		},
-		RollupCfg: rollup.Config{
-			Genesis: rollup.Genesis{
-				L1: eth.BlockID{
-					Hash:   [32]byte{1, 2},
-					Number: 100,
-				},
-				L2: eth.BlockID{
-					Hash:   [32]byte{2, 3},
-					Number: 0,
-				},
-				L2Time: now,
-				SystemConfig: eth.SystemConfig{
-					BatcherAddr: [20]byte{1},
-					Overhead:    [32]byte{1},
-					Scalar:      [32]byte{1},
-					GasLimit:    30000000,
-				},
-			},
-			BlockTime:               2,
-			MaxSequencerDrift:       600,
-			SeqWindowSize:           3600,
-			ChannelTimeoutBedrock:   300,
-			L1ChainID:               big.NewInt(1),
-			L2ChainID:               big.NewInt(2),
-			RegolithTime:            &now,
-			CanyonTime:              &now,
-			BatchInboxAddress:       [20]byte{1, 2},
-			DepositContractAddress:  [20]byte{2, 3},
-			L1SystemConfigAddress:   [20]byte{3, 4},
-			ProtocolVersionsAddress: [20]byte{4, 5},
 		},
 		RPCEnableProxy: false,
 	}

--- a/op-conductor/consensus/raft.go
+++ b/op-conductor/consensus/raft.go
@@ -13,7 +13,6 @@ import (
 	boltdb "github.com/hashicorp/raft-boltdb/v2"
 	"github.com/pkg/errors"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -23,8 +22,7 @@ var _ Consensus = (*RaftConsensus)(nil)
 
 // RaftConsensus implements Consensus using raft protocol.
 type RaftConsensus struct {
-	log       log.Logger
-	rollupCfg *rollup.Config
+	log log.Logger
 
 	serverID raft.ServerID
 	r        *raft.Raft
@@ -55,7 +53,6 @@ type RaftConsensusConfig struct {
 
 	StorageDir         string
 	Bootstrap          bool
-	RollupCfg          *rollup.Config
 	SnapshotInterval   time.Duration
 	SnapshotThreshold  uint64
 	TrailingLogs       uint64
@@ -179,7 +176,6 @@ func NewRaftConsensus(log log.Logger, cfg *RaftConsensusConfig) (*RaftConsensus,
 		r:             r,
 		serverID:      raft.ServerID(cfg.ServerID),
 		unsafeTracker: fsm,
-		rollupCfg:     cfg.RollupCfg,
 		transport:     transport,
 	}, err
 }

--- a/op-conductor/consensus/raft_test.go
+++ b/op-conductor/consensus/raft_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
@@ -19,9 +18,6 @@ import (
 func TestCommitAndRead(t *testing.T) {
 	log := testlog.Logger(t, log.LevelInfo)
 	now := uint64(time.Now().Unix())
-	rollupCfg := &rollup.Config{
-		CanyonTime: &now,
-	}
 	storageDir := "/tmp/sequencerA"
 	if err := os.RemoveAll(storageDir); err != nil {
 		t.Fatal(err)
@@ -33,7 +29,6 @@ func TestCommitAndRead(t *testing.T) {
 		AdvertisedAddr:     "",          // use local address that the server binds to
 		StorageDir:         storageDir,
 		Bootstrap:          true,
-		RollupCfg:          rollupCfg,
 		SnapshotInterval:   120 * time.Second,
 		SnapshotThreshold:  10240,
 		TrailingLogs:       8192,

--- a/op-conductor/health/monitor.go
+++ b/op-conductor/health/monitor.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-conductor/client"
 	"github.com/ethereum-optimism/optimism/op-conductor/metrics"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 )
@@ -40,13 +39,12 @@ type HealthMonitor interface {
 // safeInterval is the interval between safe head progress measured in seconds.
 // minPeerCount is the minimum number of peers required for the sequencer to be healthy.
 // rollupBoostHealthChecker is an optional health checker for rollup-boost (either standard or next client).
-func NewSequencerHealthMonitor(log log.Logger, metrics metrics.Metricer, interval, unsafeInterval, safeInterval, minPeerCount uint64, safeEnabled bool, rollupCfg *rollup.Config, node dial.RollupClientInterface, p2p apis.P2PClient, supervisor SupervisorHealthAPI, rollupBoostHealthChecker client.RollupBoostHealthChecker, elP2pClient client.ElP2PClient, minElP2pPeers uint64, rollupBoostToleratePartialHealthinessToleranceLimit uint64, rollupBoostToleratePartialHealthinessToleranceIntervalSeconds uint64) HealthMonitor {
+func NewSequencerHealthMonitor(log log.Logger, metrics metrics.Metricer, interval, unsafeInterval, safeInterval, minPeerCount uint64, safeEnabled bool, node dial.RollupClientInterface, p2p apis.P2PClient, supervisor SupervisorHealthAPI, rollupBoostHealthChecker client.RollupBoostHealthChecker, elP2pClient client.ElP2PClient, minElP2pPeers uint64, rollupBoostToleratePartialHealthinessToleranceLimit uint64, rollupBoostToleratePartialHealthinessToleranceIntervalSeconds uint64) HealthMonitor {
 	hm := &SequencerHealthMonitor{
 		log:                      log,
 		metrics:                  metrics,
 		interval:                 interval,
 		healthUpdateCh:           make(chan error),
-		rollupCfg:                rollupCfg,
 		unsafeInterval:           unsafeInterval,
 		safeEnabled:              safeEnabled,
 		safeInterval:             safeInterval,
@@ -90,7 +88,6 @@ type SequencerHealthMonitor struct {
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
 
-	rollupCfg          *rollup.Config
 	unsafeInterval     uint64
 	safeEnabled        bool
 	safeInterval       uint64

--- a/op-conductor/health/monitor_test.go
+++ b/op-conductor/health/monitor_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-conductor/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	p2pMocks "github.com/ethereum-optimism/optimism/op-node/p2p/mocks"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -40,7 +39,6 @@ type HealthMonitorTestSuite struct {
 	log          log.Logger
 	interval     uint64
 	minPeerCount uint64
-	rollupCfg    *rollup.Config
 
 	minElP2pPeerCount uint64
 }
@@ -49,9 +47,6 @@ func (s *HealthMonitorTestSuite) SetupSuite() {
 	s.log = testlog.Logger(s.T(), log.LevelDebug)
 	s.interval = interval
 	s.minPeerCount = minPeerCount
-	s.rollupCfg = &rollup.Config{
-		BlockTime: blockTime,
-	}
 	s.minElP2pPeerCount = minElP2pPeerCount
 }
 
@@ -75,7 +70,6 @@ func (s *HealthMonitorTestSuite) SetupMonitor(
 		interval:       s.interval,
 		metrics:        &metrics.NoopMetricsImpl{},
 		healthUpdateCh: make(chan error),
-		rollupCfg:      s.rollupCfg,
 		unsafeInterval: unsafeInterval,
 		safeInterval:   safeInterval,
 		safeEnabled:    true,
@@ -121,7 +115,6 @@ func (s *HealthMonitorTestSuite) SetupMonitorWithRollupBoost(
 		interval:       s.interval,
 		metrics:        &metrics.NoopMetricsImpl{},
 		healthUpdateCh: make(chan error),
-		rollupCfg:      s.rollupCfg,
 		unsafeInterval: unsafeInterval,
 		safeInterval:   safeInterval,
 		safeEnabled:    true,

--- a/op-e2e/system/conductor/sequencer_failover_setup.go
+++ b/op-e2e/system/conductor/sequencer_failover_setup.go
@@ -232,7 +232,6 @@ func setupConductor(
 			UnsafeInterval: 30,
 			SafeInterval:   30,
 		},
-		RollupCfg:      rollupCfg,
 		RPCEnableProxy: true,
 		LogConfig: oplog.CLIConfig{
 			Level: log.LevelDebug,

--- a/op-service/sources/l2_client.go
+++ b/op-service/sources/l2_client.go
@@ -46,24 +46,28 @@ func L2ClientDefaultConfig(config *rollup.Config, trustRPC bool) *L2ClientConfig
 
 func L2ClientSimpleConfig(config *rollup.Config, trustRPC bool, span, fullSpan int) *L2ClientConfig {
 	return &L2ClientConfig{
-		EthClientConfig: EthClientConfig{
-			// receipts and transactions are cached per block
-			ReceiptsCacheSize:     span,
-			TransactionsCacheSize: span,
-			HeadersCacheSize:      span,
-			PayloadsCacheSize:     span,
-			MaxRequestsPerBatch:   20,
-			MaxConcurrentRequests: 10,
-			BlockRefsCacheSize:    span,
-			TrustRPC:              trustRPC,
-			MustBePostMerge:       true,
-			RPCProviderKind:       RPCKindStandard,
-			MethodResetDuration:   time.Minute,
-		},
+		EthClientConfig: *EthClientConfigWithSpan(trustRPC, span),
 		// Not bounded by span, to cover find-sync-start range fully for speedy recovery after errors.
 		L2BlockRefsCacheSize: fullSpan,
 		L1ConfigsCacheSize:   span,
 		RollupCfg:            config,
+	}
+}
+
+func EthClientConfigWithSpan(trustRPC bool, span int) *EthClientConfig {
+	return &EthClientConfig{
+		// receipts and transactions are cached per block
+		ReceiptsCacheSize:     span,
+		TransactionsCacheSize: span,
+		HeadersCacheSize:      span,
+		PayloadsCacheSize:     span,
+		MaxRequestsPerBatch:   20,
+		MaxConcurrentRequests: 10,
+		BlockRefsCacheSize:    span,
+		TrustRPC:              trustRPC,
+		MustBePostMerge:       true,
+		RPCProviderKind:       RPCKindStandard,
+		MethodResetDuration:   time.Minute,
 	}
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Removes rollup config requirement from conductor. It's only used for the cache value for the client, so just set that to a static value (the max and generally what most L2s use anyway).

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
