### PR TITLE
op-conductor: add raft WAL backend option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/raft v1.7.3
 	github.com/hashicorp/raft-boltdb/v2 v2.3.1
+	github.com/hashicorp/raft-wal v0.4.2
 	github.com/holiman/uint256 v1.3.2
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-leveldb v0.5.0
@@ -58,7 +59,7 @@ require (
 	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.27.6
-	go.etcd.io/bbolt v1.3.5
+	go.etcd.io/bbolt v1.3.6
 	go.opentelemetry.io/otel v1.40.0
 	go.opentelemetry.io/otel/trace v1.40.0
 	golang.org/x/crypto v0.44.0
@@ -74,6 +75,10 @@ require (
 )
 
 require (
+	github.com/benbjohnson/immutable v0.4.0 // indirect
+	github.com/coreos/etcd v3.3.27+incompatible // indirect
+	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
+	github.com/coreos/pkg v0.0.0-20220810130054-c7d1c02cb6cf // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/grafana/pyroscope-go v1.2.7 // indirect
@@ -156,10 +161,10 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.11 // indirect
 	github.com/hashicorp/go-hclog v1.6.2 // indirect
-	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
+	github.com/hashicorp/go-immutable-radix v1.3.0 // indirect
 	github.com/hashicorp/go-metrics v0.5.4 // indirect
 	github.com/hashicorp/go-msgpack/v2 v2.1.2 // indirect
-	github.com/hashicorp/golang-lru v0.5.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/golang-lru/arc/v2 v2.0.7 // indirect
 	github.com/hashicorp/raft-boltdb v0.0.0-20231211162105-6c830fa4535e // indirect
 	github.com/holiman/billy v0.0.0-20250707135307-f2f9b9aae7db // indirect

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZx
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
 github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
+github.com/benbjohnson/immutable v0.4.0 h1:CTqXbEerYso8YzVPxmWxh2gnoRQbbB9X1quUC8+vGZA=
+github.com/benbjohnson/immutable v0.4.0/go.mod h1:iAr8OjJGLnLmVUr9MZ/rz4PWUy6Ouc2JLYuMArmvAJM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -161,10 +163,16 @@ github.com/consensys/gnark-crypto v0.18.1/go.mod h1:L3mXGFTe1ZN+RSJ+CLjUt9x7PNdx
 github.com/containerd/cgroups v0.0.0-20201119153540-4cbc285b3327/go.mod h1:ZJeTFisyysqgcCdecO57Dj79RfL0LNeGiFUqLYQRYLE=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
+github.com/coreos/etcd v3.3.27+incompatible h1:QIudLb9KeBsE5zyYxd1mjzRSkzLg9Wf9QlRwFgd6oTA=
+github.com/coreos/etcd v3.3.27+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
+github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/coreos/pkg v0.0.0-20220810130054-c7d1c02cb6cf h1:GOPo6vn/vTN+3IwZBvXX0y5doJfSC7My0cdzelyOCsQ=
+github.com/coreos/pkg v0.0.0-20220810130054-c7d1c02cb6cf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB0alcyc=
@@ -397,6 +405,8 @@ github.com/hashicorp/go-hclog v1.6.2 h1:NOtoftovWkDheyUM/8JW3QMiXyxJK3uHRK7wV04n
 github.com/hashicorp/go-hclog v1.6.2/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0 h1:AKDB1HM5PWEA7i4nhcpwOrO2byshxBjXVn/J/3+z5/0=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-immutable-radix v1.3.0 h1:8exGP7ego3OmkfksihtSouGMZ+hQrhxx+FVELeXpVPE=
+github.com/hashicorp/go-immutable-radix v1.3.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-metrics v0.5.4 h1:8mmPiIJkTPPEbAiV97IxdAGNdRdaWwVap1BU6elejKY=
 github.com/hashicorp/go-metrics v0.5.4/go.mod h1:CG5yz4NZ/AI/aQt9Ucm/vdBnbh7fvmv4lxZ350i+QQI=
 github.com/hashicorp/go-msgpack v0.5.5 h1:i9R9JSrqIz0QVLz3sz+i3YJdT7TTSLcfLLzJi9aZTuI=
@@ -410,6 +420,8 @@ github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCS
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru/arc/v2 v2.0.7 h1:QxkVTxwColcduO+LP7eJO56r2hFiG8zEbfAAzRv52KQ=
 github.com/hashicorp/golang-lru/arc/v2 v2.0.7/go.mod h1:Pe7gBlGdc8clY5LJ0LpJXMt5AmgmWNH1g+oFFVUHOEc=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
@@ -421,6 +433,8 @@ github.com/hashicorp/raft-boltdb v0.0.0-20231211162105-6c830fa4535e h1:SK4y8oR4Z
 github.com/hashicorp/raft-boltdb v0.0.0-20231211162105-6c830fa4535e/go.mod h1:EMz/UIuG93P0MBeHh6CbXQAEe8ckVJLZjhD17lBzK5Q=
 github.com/hashicorp/raft-boltdb/v2 v2.3.1 h1:ackhdCNPKblmOhjEU9+4lHSJYFkJd6Jqyvj6eW9pwkc=
 github.com/hashicorp/raft-boltdb/v2 v2.3.1/go.mod h1:n4S+g43dXF1tqDT+yzcXHhXM6y7MrlUd3TTwGRcUvQE=
+github.com/hashicorp/raft-wal v0.4.2 h1:DV1jgqEumNfdNpOaZ9mL1Gu7Mz59epFtiE6CoqnHrlY=
+github.com/hashicorp/raft-wal v0.4.2/go.mod h1:S92ainH+6fRuWk6BtZKJ8EgcGgNTKx48Hk5dhOOY1DM=
 github.com/holiman/billy v0.0.0-20250707135307-f2f9b9aae7db h1:IZUYC/xb3giYwBLMnr8d0TGTzPKFGNTCGgGLoyeX330=
 github.com/holiman/billy v0.0.0-20250707135307-f2f9b9aae7db/go.mod h1:xTEYN9KCHxuYHs+NmrmzFcnvHMzLLNiGFafCb1n3Mfg=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
@@ -893,6 +907,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
+go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
+go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
@@ -1051,6 +1067,7 @@ golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 
+	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
 	"github.com/ethereum-optimism/optimism/op-conductor/flags"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
@@ -35,6 +36,9 @@ type Config struct {
 
 	// RaftStorageDir is the directory to store raft data.
 	RaftStorageDir string
+
+	// RaftStorageBackend is the backend used for raft log and stable stores.
+	RaftStorageBackend string
 
 	// RaftBootstrap is true if this node should bootstrap a new raft cluster.
 	RaftBootstrap bool
@@ -117,6 +121,9 @@ func (c *Config) Check() error {
 	if c.RaftStorageDir == "" {
 		return fmt.Errorf("missing raft storage directory")
 	}
+	if !consensus.IsValidRaftStorageBackend(c.RaftStorageBackend) {
+		return fmt.Errorf("invalid raft storage backend %q", c.RaftStorageBackend)
+	}
 	if c.NodeRPC == "" {
 		return fmt.Errorf("missing node RPC")
 	}
@@ -167,6 +174,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*Config, error) {
 		RaftBootstrap:                 ctx.Bool(flags.RaftBootstrap.Name),
 		RaftServerID:                  ctx.String(flags.RaftServerID.Name),
 		RaftStorageDir:                ctx.String(flags.RaftStorageDir.Name),
+		RaftStorageBackend:            ctx.String(flags.RaftStorageBackend.Name),
 		RaftSnapshotInterval:          ctx.Duration(flags.RaftSnapshotInterval.Name),
 		RaftSnapshotThreshold:         ctx.Uint64(flags.RaftSnapshotThreshold.Name),
 		RaftTrailingLogs:              ctx.Uint64(flags.RaftTrailingLogs.Name),

--- a/op-conductor/conductor/config_test.go
+++ b/op-conductor/conductor/config_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
 )
 
 func TestConfigCheckRollupBoostAndNextMutuallyExclusive(t *testing.T) {
@@ -12,6 +14,7 @@ func TestConfigCheckRollupBoostAndNextMutuallyExclusive(t *testing.T) {
 		ConsensusPort:                 9000,
 		RaftServerID:                  "server-1",
 		RaftStorageDir:                "/tmp/op-conductor",
+		RaftStorageBackend:            consensus.RaftStorageBackendBoltDB,
 		NodeRPC:                       "http://node.example",
 		ExecutionRPC:                  "http://exec.example",
 		RollupBoostEnabled:            true,
@@ -22,4 +25,20 @@ func TestConfigCheckRollupBoostAndNextMutuallyExclusive(t *testing.T) {
 	err := cfg.Check()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "only one of rollup-boost or rollup-boost next healthchecks can be enabled")
+}
+
+func TestConfigCheckInvalidRaftStorageBackend(t *testing.T) {
+	cfg := &Config{
+		ConsensusAddr:      "127.0.0.1",
+		ConsensusPort:      9000,
+		RaftServerID:       "server-1",
+		RaftStorageDir:     "/tmp/op-conductor",
+		RaftStorageBackend: "bad-backend",
+		NodeRPC:            "http://node.example",
+		ExecutionRPC:       "http://exec.example",
+	}
+
+	err := cfg.Check()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `invalid raft storage backend "bad-backend"`)
 }

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -184,6 +184,7 @@ func (c *OpConductor) initConsensus(ctx context.Context) error {
 		ListenAddr:         c.cfg.ConsensusAddr,
 		ListenPort:         c.cfg.ConsensusPort,
 		StorageDir:         c.cfg.RaftStorageDir,
+		StorageBackend:     c.cfg.RaftStorageBackend,
 		Bootstrap:          c.cfg.RaftBootstrap,
 		SnapshotInterval:   c.cfg.RaftSnapshotInterval,
 		SnapshotThreshold:  c.cfg.RaftSnapshotThreshold,

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	clientmocks "github.com/ethereum-optimism/optimism/op-conductor/client/mocks"
+	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
 	consensusmocks "github.com/ethereum-optimism/optimism/op-conductor/consensus/mocks"
 	"github.com/ethereum-optimism/optimism/op-conductor/health"
 	healthmocks "github.com/ethereum-optimism/optimism/op-conductor/health/mocks"
@@ -31,14 +32,15 @@ import (
 
 func mockConfig(t *testing.T) Config {
 	return Config{
-		ConsensusAddr:  "127.0.0.1",
-		ConsensusPort:  0,
-		RaftServerID:   "SequencerA",
-		RaftStorageDir: "/tmp/raft",
-		RaftBootstrap:  false,
-		NodeRPC:        "http://node:8545",
-		ExecutionRPC:   "http://geth:8545",
-		Paused:         false,
+		ConsensusAddr:      "127.0.0.1",
+		ConsensusPort:      0,
+		RaftServerID:       "SequencerA",
+		RaftStorageDir:     "/tmp/raft",
+		RaftStorageBackend: consensus.RaftStorageBackendBoltDB,
+		RaftBootstrap:      false,
+		NodeRPC:            "http://node:8545",
+		ExecutionRPC:       "http://geth:8545",
+		Paused:             false,
 		HealthCheck: HealthCheckConfig{
 			Interval:       1,
 			UnsafeInterval: 3,

--- a/op-conductor/consensus/raft.go
+++ b/op-conductor/consensus/raft.go
@@ -3,6 +3,7 @@ package consensus
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -11,12 +12,18 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/hashicorp/raft"
 	boltdb "github.com/hashicorp/raft-boltdb/v2"
+	wal "github.com/hashicorp/raft-wal"
 	"github.com/pkg/errors"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 const defaultTimeout = 5 * time.Second
+
+const (
+	RaftStorageBackendBoltDB = "boltdb"
+	RaftStorageBackendWAL    = "wal"
+)
 
 var _ Consensus = (*RaftConsensus)(nil)
 
@@ -28,6 +35,8 @@ type RaftConsensus struct {
 
 	serverID raft.ServerID
 	r        *raft.Raft
+
+	storeCloser io.Closer
 
 	transport *raft.NetworkTransport
 	// advertisedAddr is the host & port to contact this server.
@@ -54,6 +63,7 @@ type RaftConsensusConfig struct {
 	ListenAddr string
 
 	StorageDir         string
+	StorageBackend     string
 	Bootstrap          bool
 	SnapshotInterval   time.Duration
 	SnapshotThreshold  uint64
@@ -64,6 +74,24 @@ type RaftConsensusConfig struct {
 	// Metrics collects sub-operation timing data for the commit path.
 	// If nil, no metrics are recorded.
 	Metrics ConsensusMetrics
+}
+
+// IsValidRaftStorageBackend returns true if backend is supported.
+// The empty value is accepted for backwards-compatible programmatic configs.
+func IsValidRaftStorageBackend(backend string) bool {
+	switch normalizeRaftStorageBackend(backend) {
+	case RaftStorageBackendBoltDB, RaftStorageBackendWAL:
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeRaftStorageBackend(backend string) string {
+	if backend == "" {
+		return RaftStorageBackendBoltDB
+	}
+	return backend
 }
 
 // checkTCPPortOpen attempts to connect to the specified address and returns an error if the connection fails.
@@ -93,19 +121,16 @@ func NewRaftConsensus(log log.Logger, cfg *RaftConsensusConfig) (*RaftConsensus,
 		}
 	}
 
-	var err error
-	logStorePath := filepath.Join(baseDir, "raft-log.db")
-	boltLogStore, err := boltdb.NewBoltStore(logStorePath)
+	stores, err := openRaftStores(log, baseDir, cfg.StorageBackend, cfg.Metrics)
 	if err != nil {
-		return nil, fmt.Errorf(`boltdb.NewBoltStore(%q): %w`, logStorePath, err)
+		return nil, err
 	}
-	logStore := wrapInstrumentedLogStore(boltLogStore, cfg.Metrics)
-
-	stableStorePath := filepath.Join(baseDir, "raft-stable.db")
-	stableStore, err := boltdb.NewBoltStore(stableStorePath)
-	if err != nil {
-		return nil, fmt.Errorf(`boltdb.NewBoltStore(%q): %w`, stableStorePath, err)
-	}
+	storesOwned := false
+	defer func() {
+		if !storesOwned && stores.closer != nil {
+			_ = stores.closer.Close()
+		}
+	}()
 
 	snapshotStore, err := raft.NewFileSnapshotStoreWithLogger(baseDir, 1, rc.Logger)
 	if err != nil {
@@ -140,7 +165,7 @@ func NewRaftConsensus(log log.Logger, cfg *RaftConsensusConfig) (*RaftConsensus,
 
 	fsm := NewUnsafeHeadTracker(log, cfg.Metrics)
 
-	r, err := raft.NewRaft(rc, fsm, logStore, stableStore, snapshotStore, transport)
+	r, err := raft.NewRaft(rc, fsm, stores.logStore, stores.stableStore, snapshotStore, transport)
 	if err != nil {
 		log.Error("failed to create raft", "err", err)
 		return nil, errors.Wrap(err, "failed to create raft")
@@ -178,14 +203,88 @@ func NewRaftConsensus(log log.Logger, cfg *RaftConsensusConfig) (*RaftConsensus,
 		}
 	}
 
+	storesOwned = true
 	return &RaftConsensus{
 		log:           log,
 		metrics:       cfg.Metrics,
 		r:             r,
 		serverID:      raft.ServerID(cfg.ServerID),
+		storeCloser:   stores.closer,
 		unsafeTracker: fsm,
 		transport:     transport,
 	}, err
+}
+
+type raftStoreSet struct {
+	logStore    raft.LogStore
+	stableStore raft.StableStore
+	closer      io.Closer
+}
+
+func openRaftStores(log log.Logger, baseDir string, backend string, metrics ConsensusMetrics) (*raftStoreSet, error) {
+	switch normalizeRaftStorageBackend(backend) {
+	case RaftStorageBackendBoltDB:
+		return openBoltDBRaftStores(baseDir, metrics)
+	case RaftStorageBackendWAL:
+		return openWALRaftStores(log, baseDir, metrics)
+	default:
+		return nil, fmt.Errorf("unsupported raft storage backend %q", backend)
+	}
+}
+
+func openBoltDBRaftStores(baseDir string, metrics ConsensusMetrics) (*raftStoreSet, error) {
+	logStorePath := filepath.Join(baseDir, "raft-log.db")
+	boltLogStore, err := boltdb.NewBoltStore(logStorePath)
+	if err != nil {
+		return nil, fmt.Errorf(`boltdb.NewBoltStore(%q): %w`, logStorePath, err)
+	}
+
+	stableStorePath := filepath.Join(baseDir, "raft-stable.db")
+	stableStore, err := boltdb.NewBoltStore(stableStorePath)
+	if err != nil {
+		_ = boltLogStore.Close()
+		return nil, fmt.Errorf(`boltdb.NewBoltStore(%q): %w`, stableStorePath, err)
+	}
+
+	return &raftStoreSet{
+		logStore:    wrapInstrumentedLogStore(boltLogStore, metrics),
+		stableStore: stableStore,
+		closer:      closeFunc(func() error { return closeRaftStores(boltLogStore, stableStore) }),
+	}, nil
+}
+
+func openWALRaftStores(log log.Logger, baseDir string, metrics ConsensusMetrics) (*raftStoreSet, error) {
+	walDir := filepath.Join(baseDir, "raft-wal")
+	if err := os.MkdirAll(walDir, 0o755); err != nil {
+		return nil, fmt.Errorf("error creating raft wal dir: %w", err)
+	}
+
+	walStore, err := wal.Open(walDir)
+	if err != nil {
+		return nil, fmt.Errorf(`wal.Open(%q): %w`, walDir, err)
+	}
+	log.Info("Using raft WAL storage backend", "dir", walDir)
+
+	return &raftStoreSet{
+		logStore:    wrapInstrumentedLogStore(walStore, metrics),
+		stableStore: walStore,
+		closer:      walStore,
+	}, nil
+}
+
+type closeFunc func() error
+
+func (f closeFunc) Close() error {
+	return f()
+}
+
+func closeRaftStores(closers ...io.Closer) error {
+	for _, closer := range closers {
+		if err := closer.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func wrapInstrumentedLogStore(store raft.LogStore, metrics ConsensusMetrics) raft.LogStore {
@@ -219,6 +318,11 @@ func (s *instrumentedLogStore) StoreLogs(logEntries []*raft.Log) error {
 		s.metrics.RecordLogStoreDuration(time.Since(start).Seconds())
 	}
 	return err
+}
+
+func (s *instrumentedLogStore) IsMonotonic() bool {
+	store, ok := s.LogStore.(raft.MonotonicLogStore)
+	return ok && store.IsMonotonic()
 }
 
 // Addr returns the address to contact this raft consensus server.
@@ -328,6 +432,12 @@ func (rc *RaftConsensus) Shutdown() error {
 	if err := rc.r.Shutdown().Error(); err != nil {
 		rc.log.Error("failed to shutdown raft", "err", err)
 		return err
+	}
+	if rc.storeCloser != nil {
+		if err := rc.storeCloser.Close(); err != nil {
+			rc.log.Error("failed to close raft stores", "err", err)
+			return err
+		}
 	}
 	return nil
 }

--- a/op-conductor/consensus/raft_test.go
+++ b/op-conductor/consensus/raft_test.go
@@ -1,7 +1,6 @@
 package consensus
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -16,67 +15,72 @@ import (
 )
 
 func TestCommitAndRead(t *testing.T) {
-	log := testlog.Logger(t, log.LevelInfo)
-	now := uint64(time.Now().Unix())
-	storageDir := "/tmp/sequencerA"
-	if err := os.RemoveAll(storageDir); err != nil {
-		t.Fatal(err)
+	for _, storageBackend := range []string{RaftStorageBackendBoltDB, RaftStorageBackendWAL} {
+		t.Run(storageBackend, func(t *testing.T) {
+			log := testlog.Logger(t, log.LevelInfo)
+			now := uint64(time.Now().Unix())
+			storageDir := t.TempDir()
+			raftConsensusConfig := &RaftConsensusConfig{
+				ServerID:           "SequencerA",
+				ListenPort:         0,
+				ListenAddr:         "127.0.0.1", // local test, don't bind to external interface
+				AdvertisedAddr:     "",          // use local address that the server binds to
+				StorageDir:         storageDir,
+				StorageBackend:     storageBackend,
+				Bootstrap:          true,
+				SnapshotInterval:   time.Second,
+				SnapshotThreshold:  48,
+				TrailingLogs:       32,
+				HeartbeatTimeout:   1000 * time.Millisecond,
+				LeaderLeaseTimeout: 500 * time.Millisecond,
+			}
+
+			cons, err := NewRaftConsensus(log, raftConsensusConfig)
+			require.NoError(t, err)
+			defer func() {
+				require.NoError(t, cons.Shutdown())
+			}()
+
+			// wait till it became leader
+			<-cons.LeaderCh()
+
+			// eth.BlockV1
+			payload := &eth.ExecutionPayloadEnvelope{
+				ExecutionPayload: &eth.ExecutionPayload{
+					BlockNumber:  1,
+					Timestamp:    hexutil.Uint64(now - 20),
+					Transactions: []eth.Data{},
+					ExtraData:    []byte{},
+				},
+			}
+
+			err = cons.CommitUnsafePayload(payload)
+			// ExecutionPayloadEnvelope is expected to fail when unmarshalling a blockV1
+			require.Error(t, err)
+
+			// eth.BlockV3
+			one := hexutil.Uint64(1)
+			hash := common.HexToHash("0x12345")
+			payload = &eth.ExecutionPayloadEnvelope{
+				ParentBeaconBlockRoot: &hash,
+				ExecutionPayload: &eth.ExecutionPayload{
+					BlockNumber:   2,
+					Timestamp:     hexutil.Uint64(time.Now().Unix()),
+					Transactions:  []eth.Data{},
+					ExtraData:     []byte{},
+					Withdrawals:   &types.Withdrawals{},
+					ExcessBlobGas: &one,
+					BlobGasUsed:   &one,
+				},
+			}
+
+			err = cons.CommitUnsafePayload(payload)
+			// ExecutionPayloadEnvelope is expected to succeed when unmarshalling a blockV3
+			require.NoError(t, err)
+
+			unsafeHead, err := cons.LatestUnsafePayload()
+			require.NoError(t, err)
+			require.Equal(t, payload, unsafeHead)
+		})
 	}
-	raftConsensusConfig := &RaftConsensusConfig{
-		ServerID:           "SequencerA",
-		ListenPort:         0,
-		ListenAddr:         "127.0.0.1", // local test, don't bind to external interface
-		AdvertisedAddr:     "",          // use local address that the server binds to
-		StorageDir:         storageDir,
-		Bootstrap:          true,
-		SnapshotInterval:   120 * time.Second,
-		SnapshotThreshold:  10240,
-		TrailingLogs:       8192,
-		HeartbeatTimeout:   1000 * time.Millisecond,
-		LeaderLeaseTimeout: 500 * time.Millisecond,
-	}
-
-	cons, err := NewRaftConsensus(log, raftConsensusConfig)
-	require.NoError(t, err)
-
-	// wait till it became leader
-	<-cons.LeaderCh()
-
-	// eth.BlockV1
-	payload := &eth.ExecutionPayloadEnvelope{
-		ExecutionPayload: &eth.ExecutionPayload{
-			BlockNumber:  1,
-			Timestamp:    hexutil.Uint64(now - 20),
-			Transactions: []eth.Data{},
-			ExtraData:    []byte{},
-		},
-	}
-
-	err = cons.CommitUnsafePayload(payload)
-	// ExecutionPayloadEnvelope is expected to fail when unmarshalling a blockV1
-	require.Error(t, err)
-
-	// eth.BlockV3
-	one := hexutil.Uint64(1)
-	hash := common.HexToHash("0x12345")
-	payload = &eth.ExecutionPayloadEnvelope{
-		ParentBeaconBlockRoot: &hash,
-		ExecutionPayload: &eth.ExecutionPayload{
-			BlockNumber:   2,
-			Timestamp:     hexutil.Uint64(time.Now().Unix()),
-			Transactions:  []eth.Data{},
-			ExtraData:     []byte{},
-			Withdrawals:   &types.Withdrawals{},
-			ExcessBlobGas: &one,
-			BlobGasUsed:   &one,
-		},
-	}
-
-	err = cons.CommitUnsafePayload(payload)
-	// ExecutionPayloadEnvelope is expected to succeed when unmarshalling a blockV3
-	require.NoError(t, err)
-
-	unsafeHead, err := cons.LatestUnsafePayload()
-	require.NoError(t, err)
-	require.Equal(t, payload, unsafeHead)
 }

--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -51,6 +51,12 @@ var (
 		Usage:   "Directory to store raft data",
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "RAFT_STORAGE_DIR"),
 	}
+	RaftStorageBackend = &cli.StringFlag{
+		Name:    "raft.storage.backend",
+		Usage:   "Raft storage backend to use for log and stable stores: boltdb or wal",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "RAFT_STORAGE_BACKEND"),
+		Value:   "boltdb",
+	}
 	RaftSnapshotInterval = &cli.DurationFlag{
 		Name:    "raft.snapshot-interval",
 		Usage:   "The interval to check if a snapshot should be taken.",
@@ -220,6 +226,7 @@ var optionalFlags = []cli.Flag{
 	Paused,
 	RPCEnableProxy,
 	RaftBootstrap,
+	RaftStorageBackend,
 	HealthCheckSafeEnabled,
 	HealthCheckSafeInterval,
 	RaftSnapshotInterval,


### PR DESCRIPTION
Adds a new configuration option to specify the op-conductor raft backend. This defaults to boltdb (unchanged), but adds a new "wal" option which leverages the https://github.com/hashicorp/raft-wal storage backend for improved performance.