### PR TITLE
op-conductor: Collect underlying raft metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -156,10 +156,10 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.11 // indirect
 	github.com/hashicorp/go-hclog v1.6.2 // indirect
-	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
-	github.com/hashicorp/go-metrics v0.5.4 // indirect
+	github.com/hashicorp/go-immutable-radix v1.3.0 // indirect
+	github.com/hashicorp/go-metrics v0.5.4
 	github.com/hashicorp/go-msgpack/v2 v2.1.2 // indirect
-	github.com/hashicorp/golang-lru v0.5.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/golang-lru/arc/v2 v2.0.7 // indirect
 	github.com/hashicorp/raft-boltdb v0.0.0-20231211162105-6c830fa4535e // indirect
 	github.com/holiman/billy v0.0.0-20250707135307-f2f9b9aae7db // indirect

--- a/go.sum
+++ b/go.sum
@@ -397,6 +397,8 @@ github.com/hashicorp/go-hclog v1.6.2 h1:NOtoftovWkDheyUM/8JW3QMiXyxJK3uHRK7wV04n
 github.com/hashicorp/go-hclog v1.6.2/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0 h1:AKDB1HM5PWEA7i4nhcpwOrO2byshxBjXVn/J/3+z5/0=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-immutable-radix v1.3.0 h1:8exGP7ego3OmkfksihtSouGMZ+hQrhxx+FVELeXpVPE=
+github.com/hashicorp/go-immutable-radix v1.3.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-metrics v0.5.4 h1:8mmPiIJkTPPEbAiV97IxdAGNdRdaWwVap1BU6elejKY=
 github.com/hashicorp/go-metrics v0.5.4/go.mod h1:CG5yz4NZ/AI/aQt9Ucm/vdBnbh7fvmv4lxZ350i+QQI=
 github.com/hashicorp/go-msgpack v0.5.5 h1:i9R9JSrqIz0QVLz3sz+i3YJdT7TTSLcfLLzJi9aZTuI=
@@ -410,6 +412,8 @@ github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCS
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru/arc/v2 v2.0.7 h1:QxkVTxwColcduO+LP7eJO56r2hFiG8zEbfAAzRv52KQ=
 github.com/hashicorp/golang-lru/arc/v2 v2.0.7/go.mod h1:Pe7gBlGdc8clY5LJ0LpJXMt5AmgmWNH1g+oFFVUHOEc=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=

--- a/op-conductor/metrics/metrics.go
+++ b/op-conductor/metrics/metrics.go
@@ -2,10 +2,13 @@ package metrics
 
 import (
 	"strconv"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
 	"github.com/ethereum-optimism/optimism/op-service/httputil"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	hashicorpmetrics "github.com/hashicorp/go-metrics/compat"
+	hashicorpprom "github.com/hashicorp/go-metrics/compat/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -71,6 +74,7 @@ var _ Metricer = (*Metrics)(nil)
 
 func NewMetrics() *Metrics {
 	registry := opmetrics.NewRegistry()
+	registerHashicorpRaftMetrics(registry)
 	factory := opmetrics.With(registry)
 
 	return &Metrics{
@@ -175,6 +179,28 @@ func NewMetrics() *Metrics {
 			Help:      "Time (in seconds) spent writing raft log entries to the underlying log store",
 			Buckets:   []float64{.0001, .00025, .0005, .001, .0025, .005, .01, .025, .05},
 		}),
+	}
+}
+
+func registerHashicorpRaftMetrics(registry *prometheus.Registry) {
+	sink, err := hashicorpprom.NewPrometheusSinkFrom(hashicorpprom.PrometheusOpts{
+		Expiration: 0,
+		Registerer: registry,
+		Name:       Namespace + "_hashicorp_raft",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	cfg := hashicorpmetrics.DefaultConfig(Namespace)
+	cfg.EnableHostname = false
+	cfg.EnableHostnameLabel = false
+	cfg.EnableRuntimeMetrics = false
+	cfg.TimerGranularity = time.Second
+	cfg.FilterDefault = false
+	cfg.AllowedPrefixes = []string{Namespace + ".raft"}
+	if _, err := hashicorpmetrics.NewGlobal(cfg, sink); err != nil {
+		panic(err)
 	}
 }
 


### PR DESCRIPTION
Collect all underlying hashicorp raft metrics under the `op_conductor_hashicorp_raft` namespace