### PR TITLE
op-conductor: raise RPC HTTP body limit to 15MB

### DIFF
--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -286,6 +286,9 @@ func (oc *OpConductor) initRPCServer(ctx context.Context) error {
 		oc.version,
 		oprpc.WithLogger(oc.log),
 		oprpc.WithRPCRecorder(oc.metrics.NewRecorder("main")),
+		// op-node commits unsafe payloads via conductor_commitUnsafePayload; raise the
+		// HTTP body limit above the go-ethereum default to accommodate large payloads.
+		oprpc.WithHTTPBodyLimit(15*1024*1024),
 	)
 	api := conductorrpc.NewAPIBackend(oc.log, oc)
 	server.AddAPI(rpc.API{

--- a/op-service/rpc/handler.go
+++ b/op-service/rpc/handler.go
@@ -40,6 +40,9 @@ type Handler struct {
 	jwtSecret      []byte
 	wsEnabled      bool
 	httpRecorder   opmetrics.HTTPRecorder
+	// httpBodyLimit overrides the max HTTP request body size for RPC servers
+	// created by this handler. If 0, the go-ethereum default is used.
+	httpBodyLimit int
 
 	log         log.Logger
 	middlewares []Middleware
@@ -160,6 +163,9 @@ func (b *Handler) AddRPCWithAuthentication(route string, isAuthenticated *bool) 
 
 	srv := rpc.NewServer()
 	srv.SetRecorder(b.recorder)
+	if b.httpBodyLimit > 0 {
+		srv.SetHTTPBodyLimit(b.httpBodyLimit)
+	}
 
 	if err := srv.RegisterName("health", &healthzAPI{
 		appVersion: b.appVersion,

--- a/op-service/rpc/handler_options.go
+++ b/op-service/rpc/handler_options.go
@@ -47,6 +47,15 @@ func WithJWTSecret(secret []byte) Option {
 	}
 }
 
+// WithHTTPBodyLimit overrides the maximum HTTP request body size (in bytes)
+// accepted by the RPC servers created by this handler. If not set, the
+// go-ethereum default is used.
+func WithHTTPBodyLimit(limit int) Option {
+	return func(b *Handler) {
+		b.httpBodyLimit = limit
+	}
+}
+
 func WithHTTPRecorder(recorder opmetrics.HTTPRecorder) Option {
 	return func(b *Handler) {
 		b.httpRecorder = recorder


### PR DESCRIPTION
op-conductor's RPC server inherited go-ethereum's default HTTP request body limit, which capped payloads committed by op-node via conductor_commitUnsafePayload. Add a WithHTTPBodyLimit option to the op-service RPC handler and use it in op-conductor to raise the limit to 15MB. The option is only applied when set, so other op-service RPC servers keep the go-ethereum default.